### PR TITLE
Add wooden border to poker table

### DIFF
--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -100,9 +100,10 @@ class TableDrawer:
             table_color[3],
         )
 
-        # Colors for the wooden border
+        # Color for the wooden border
         wood_color = (133, 94, 66, 255)
-        wood_darker = tuple(max(0, c - 40) for c in wood_color[:3]) + (wood_color[3],)
+        wood_light = tuple(min(255, c + 40) for c in wood_color[:3]) + (wood_color[3],)
+        wood_dark = tuple(max(0, c - 40) for c in wood_color[:3]) + (wood_color[3],)
 
         # ------------------------------------------------------------------
         # Background shadow of the table
@@ -131,11 +132,11 @@ class TableDrawer:
         )
         overlay_draw = ImageDraw.Draw(table_overlay, "RGBA")
 
-        # Draw wooden border with simple 3D look
+        # Draw wooden border
         overlay_draw.rounded_rectangle(
             outer_bottom_bbox,
             radius=radius + border_thickness,
-            fill=wood_darker,
+            fill=wood_color,
         )
         overlay_draw.rounded_rectangle(
             bottom_bbox, radius=radius, fill=darker_color
@@ -146,15 +147,29 @@ class TableDrawer:
         overlay_draw.rounded_rectangle(top_bbox, radius=radius, fill=table_color)
 
         line_width = 3 * scale_factor
-        wood_light = tuple(min(255, c + 40) for c in wood_color[:3]) + (
-            wood_color[3],
+
+        # Create subtle highlight and shadow to give the border a rounded look
+        light_shadow = Image.new(
+            "RGBA", (self.config.width, self.config.height), (0, 0, 0, 0)
         )
-        overlay_draw.rounded_rectangle(
+        shadow_draw = ImageDraw.Draw(light_shadow, "RGBA")
+        shadow_draw.rounded_rectangle(
             outer_top_bbox,
             radius=radius + border_thickness,
             outline=wood_light,
-            width=max(1, border_thickness // 2),
+            width=border_thickness,
         )
+        shadow_draw.rounded_rectangle(
+            outer_bottom_bbox,
+            radius=radius + border_thickness,
+            outline=wood_dark,
+            width=border_thickness,
+        )
+        light_shadow = light_shadow.filter(
+            ImageFilter.GaussianBlur(radius=border_thickness // 2)
+        )
+        table_overlay = Image.alpha_composite(table_overlay, light_shadow)
+
         overlay_draw.rounded_rectangle(
             outer_top_bbox,
             radius=radius + border_thickness,

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -70,13 +70,36 @@ class TableDrawer:
         table_right = table_left + table_width
         table_bottom = table_top + table_height
 
+        # Thickness of the wooden border around the table
+        border_thickness = int(min(table_width, table_height) * 0.05)
+
         # Thickness of the table for the 3D look
         depth = max(6, table_height // 12)
 
         top_bbox = [table_left, table_top, table_right, table_bottom]
         bottom_bbox = [table_left, table_top + depth, table_right, table_bottom + depth]
 
-        darker_color = tuple(max(0, c - 40) for c in table_color[:3]) + (table_color[3],)
+        # Bounding boxes including the wooden border
+        outer_top_bbox = [
+            table_left - border_thickness,
+            table_top - border_thickness,
+            table_right + border_thickness,
+            table_bottom + border_thickness,
+        ]
+        outer_bottom_bbox = [
+            table_left - border_thickness,
+            table_top + depth - border_thickness,
+            table_right + border_thickness,
+            table_bottom + depth + border_thickness,
+        ]
+
+        darker_color = tuple(max(0, c - 40) for c in table_color[:3]) + (
+            table_color[3],
+        )
+
+        # Colors for the wooden border
+        wood_color = (133, 94, 66, 255)
+        wood_darker = tuple(max(0, c - 40) for c in wood_color[:3]) + (wood_color[3],)
 
         # ------------------------------------------------------------------
         # Background shadow of the table
@@ -85,10 +108,10 @@ class TableDrawer:
         shadow_draw = ImageDraw.Draw(shadow_overlay, "RGBA")
         shadow_offset = depth * 2
         shadow_bbox = [
-            table_left + shadow_offset,
-            table_top + depth + shadow_offset,
-            table_right + shadow_offset,
-            table_bottom + depth + shadow_offset,
+            table_left - border_thickness + shadow_offset,
+            table_top + depth - border_thickness + shadow_offset,
+            table_right + border_thickness + shadow_offset,
+            table_bottom + depth + border_thickness + shadow_offset,
         ]
         shadow_draw.ellipse(shadow_bbox, fill=(0, 0, 0, 120))
         shadow_overlay = shadow_overlay.filter(ImageFilter.GaussianBlur(radius=depth))
@@ -98,12 +121,19 @@ class TableDrawer:
         # ------------------------------------------------------------------
         # Table surface
         # ------------------------------------------------------------------
-        table_overlay = Image.new("RGBA", (self.config.width, self.config.height), (0, 0, 0, 0))
+        table_overlay = Image.new(
+            "RGBA", (self.config.width, self.config.height), (0, 0, 0, 0)
+        )
         overlay_draw = ImageDraw.Draw(table_overlay, "RGBA")
+
+        # Draw wooden border with simple 3D look
+        overlay_draw.ellipse(outer_bottom_bbox, fill=wood_darker)
         overlay_draw.ellipse(bottom_bbox, fill=darker_color)
+        overlay_draw.ellipse(outer_top_bbox, fill=wood_color)
         overlay_draw.ellipse(top_bbox, fill=table_color)
 
         line_width = 3 * scale_factor
+        overlay_draw.ellipse(outer_top_bbox, outline=(0, 0, 0, 255), width=line_width)
         overlay_draw.ellipse(top_bbox, outline=(0, 0, 0, 255), width=line_width)
 
         self.img = Image.alpha_composite(self.img, table_overlay)

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -71,7 +71,7 @@ class TableDrawer:
         table_bottom = table_top + table_height
 
         # Thickness of the wooden border around the table
-        border_thickness = int(min(table_width, table_height) * 0.05)
+        border_thickness = int(min(table_width, table_height) * 0.08)
 
         # Thickness of the table for the 3D look
         depth = max(6, table_height // 12)
@@ -89,11 +89,11 @@ class TableDrawer:
             table_right + border_thickness,
             table_bottom + border_thickness,
         ]
-        outer_bottom_bbox = [
+        side_bbox = [
             table_left - border_thickness,
-            table_top + depth - border_thickness,
+            table_top,
             table_right + border_thickness,
-            table_bottom + depth + border_thickness,
+            table_bottom + depth,
         ]
 
         darker_color = tuple(max(0, c - 25) for c in table_color[:3]) + (
@@ -134,9 +134,9 @@ class TableDrawer:
         )
         overlay_draw = ImageDraw.Draw(table_overlay, "RGBA")
 
-        # Draw the bottom portion for the 3D effect
+        # Draw the side of the table for the 3D effect
         overlay_draw.rounded_rectangle(
-            outer_bottom_bbox,
+            side_bbox,
             radius=radius + border_thickness,
             fill=wood_color,
         )

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -64,7 +64,7 @@ class TableDrawer:
         self.draw = ImageDraw.Draw(self.img, "RGBA")
 
         # ------------------------------------------------------------------
-        # Draw the table using two ellipses to simulate perspective
+        # Draw the table using rounded rectangles to simulate perspective
         table_left = table_center_x - table_width // 2
         table_top = table_center_y - table_height // 2
         table_right = table_left + table_width
@@ -75,6 +75,9 @@ class TableDrawer:
 
         # Thickness of the table for the 3D look
         depth = max(6, table_height // 12)
+
+        # Radius for the rounded edges (half the height makes the sides straight)
+        radius = table_height // 2
 
         top_bbox = [table_left, table_top, table_right, table_bottom]
         bottom_bbox = [table_left, table_top + depth, table_right, table_bottom + depth]
@@ -113,7 +116,9 @@ class TableDrawer:
             table_right + border_thickness + shadow_offset,
             table_bottom + depth + border_thickness + shadow_offset,
         ]
-        shadow_draw.ellipse(shadow_bbox, fill=(0, 0, 0, 120))
+        shadow_draw.rounded_rectangle(
+            shadow_bbox, radius=radius + border_thickness, fill=(0, 0, 0, 120)
+        )
         shadow_overlay = shadow_overlay.filter(ImageFilter.GaussianBlur(radius=depth))
         self.img = Image.alpha_composite(self.img, shadow_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")
@@ -127,14 +132,38 @@ class TableDrawer:
         overlay_draw = ImageDraw.Draw(table_overlay, "RGBA")
 
         # Draw wooden border with simple 3D look
-        overlay_draw.ellipse(outer_bottom_bbox, fill=wood_darker)
-        overlay_draw.ellipse(bottom_bbox, fill=darker_color)
-        overlay_draw.ellipse(outer_top_bbox, fill=wood_color)
-        overlay_draw.ellipse(top_bbox, fill=table_color)
+        overlay_draw.rounded_rectangle(
+            outer_bottom_bbox,
+            radius=radius + border_thickness,
+            fill=wood_darker,
+        )
+        overlay_draw.rounded_rectangle(
+            bottom_bbox, radius=radius, fill=darker_color
+        )
+        overlay_draw.rounded_rectangle(
+            outer_top_bbox, radius=radius + border_thickness, fill=wood_color
+        )
+        overlay_draw.rounded_rectangle(top_bbox, radius=radius, fill=table_color)
 
         line_width = 3 * scale_factor
-        overlay_draw.ellipse(outer_top_bbox, outline=(0, 0, 0, 255), width=line_width)
-        overlay_draw.ellipse(top_bbox, outline=(0, 0, 0, 255), width=line_width)
+        wood_light = tuple(min(255, c + 40) for c in wood_color[:3]) + (
+            wood_color[3],
+        )
+        overlay_draw.rounded_rectangle(
+            outer_top_bbox,
+            radius=radius + border_thickness,
+            outline=wood_light,
+            width=max(1, border_thickness // 2),
+        )
+        overlay_draw.rounded_rectangle(
+            outer_top_bbox,
+            radius=radius + border_thickness,
+            outline=(0, 0, 0, 255),
+            width=line_width,
+        )
+        overlay_draw.rounded_rectangle(
+            top_bbox, radius=radius, outline=(0, 0, 0, 255), width=line_width
+        )
 
         self.img = Image.alpha_composite(self.img, table_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -96,14 +96,16 @@ class TableDrawer:
             table_bottom + depth + border_thickness,
         ]
 
-        darker_color = tuple(max(0, c - 40) for c in table_color[:3]) + (
+        darker_color = tuple(max(0, c - 25) for c in table_color[:3]) + (
             table_color[3],
         )
 
         # Color for the wooden border
         wood_color = (133, 94, 66, 255)
-        wood_light = tuple(min(255, c + 40) for c in wood_color[:3]) + (wood_color[3],)
-        wood_dark = tuple(max(0, c - 40) for c in wood_color[:3]) + (wood_color[3],)
+
+        # Slightly lighter and darker shades used only for lighting effects
+        wood_light = tuple(min(255, c + 20) for c in wood_color[:3]) + (120,)
+        wood_dark = tuple(max(0, c - 20) for c in wood_color[:3]) + (120,)
 
         # ------------------------------------------------------------------
         # Background shadow of the table
@@ -146,27 +148,28 @@ class TableDrawer:
         )
         overlay_draw.rounded_rectangle(top_bbox, radius=radius, fill=table_color)
 
-        line_width = 3 * scale_factor
+        line_width = 2 * scale_factor
 
         # Create subtle highlight and shadow to give the border a rounded look
         light_shadow = Image.new(
             "RGBA", (self.config.width, self.config.height), (0, 0, 0, 0)
         )
         shadow_draw = ImageDraw.Draw(light_shadow, "RGBA")
+        highlight_width = max(1, border_thickness // 2)
         shadow_draw.rounded_rectangle(
             outer_top_bbox,
             radius=radius + border_thickness,
             outline=wood_light,
-            width=border_thickness,
+            width=highlight_width,
         )
         shadow_draw.rounded_rectangle(
             outer_bottom_bbox,
             radius=radius + border_thickness,
             outline=wood_dark,
-            width=border_thickness,
+            width=highlight_width,
         )
         light_shadow = light_shadow.filter(
-            ImageFilter.GaussianBlur(radius=border_thickness // 2)
+            ImageFilter.GaussianBlur(radius=max(1, highlight_width // 2))
         )
         table_overlay = Image.alpha_composite(table_overlay, light_shadow)
 


### PR DESCRIPTION
## Summary
- give the table a wood border to match casino-style poker tables
- keep 3D look and shadow placement intact

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68582bf1037c8333aedae1ca7b4f7d4b