### PR TITLE
Enhance poker table visuals

### DIFF
--- a/poker_viz/game_data.py
+++ b/poker_viz/game_data.py
@@ -41,6 +41,20 @@ class GameDataProcessor:
             # Convert chips_on_table to float or default to 0
             player["chips_on_table"] = float(player.get("chips_on_table", 0))
 
+    def get_scenario_description(self):
+        """Return a simple scenario description string."""
+        if not self.players:
+            return ""
+
+        avg_stack = sum(float(p.get("stack", 0)) for p in self.players) / len(
+            self.players
+        )
+        players_left = len(self.players)
+
+        avg_stack_bb = int(round(avg_stack))
+
+        return f"{avg_stack_bb}bb, {players_left} players"
+
     def get_position_mapping(self):
         """
         Calculate position mapping based on hero position.

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -220,26 +220,11 @@ class TableDrawer:
             logo = Image.open(logo_path).convert("RGBA")
             max_w = accent_bbox[2] - accent_bbox[0]
             max_h = accent_bbox[3] - accent_bbox[1]
+            target_size = (int(max_w * 0.5), int(max_h * 0.5))
+            logo.thumbnail(target_size, Image.LANCZOS)
+            alpha = logo.split()[-1].point(lambda a: int(a * 0.2))
+            logo.putalpha(alpha)
             logo_height = logo.height
-        # Scenario description above the logo
-        scenario_text = self.game_data.get_scenario_description()
-        scenario_width = self.draw.textlength(scenario_text, font=self.title_font)
-        scenario_height = self.title_font.getbbox(scenario_text)[3]
-        scenario_y = (
-            table_center_y - logo_height / 2 - scenario_height - 5
-        )
-        self.draw.text(
-            (table_center_x - scenario_width / 2, scenario_y),
-            scenario_text,
-            fill=text_color,
-            font=self.title_font,
-        )
-
-        # Draw the pot below the logo
-        pot_width = self.draw.textlength(pot_text, font=self.player_font)
-        pot_y = table_center_y + logo_height / 2 + 5
-            (table_center_x - pot_width / 2, pot_y),
-            font=self.player_font,
             lx = int(table_center_x - logo.width / 2)
             ly = int(table_center_y - logo.height / 2)
             table_overlay.alpha_composite(logo, (lx, ly))
@@ -257,14 +242,27 @@ class TableDrawer:
         self.img = Image.alpha_composite(self.img, table_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")
 
-        # Draw the pot
+        # Scenario description above the logo
+        scenario_text = self.game_data.get_scenario_description()
+        scenario_width = self.draw.textlength(scenario_text, font=self.title_font)
+        scenario_height = self.title_font.getbbox(scenario_text)[3]
+        scenario_y = table_center_y - logo_height / 2 - scenario_height - 5
+        # self.draw.text(
+        #     (table_center_x - scenario_width / 2, scenario_y),
+        #     scenario_text,
+        #     fill=text_color,
+        #     font=self.player_font,
+        # )
+
+        # Draw the pot below the logo
         pot_text = f"Pot: {self.game_data.pot} BB"
-        text_width = self.draw.textlength(pot_text, font=self.title_font)
+        pot_width = self.draw.textlength(pot_text, font=self.player_font)
+        pot_y = table_center_y + logo_height / 4 + 15
         self.draw.text(
-            (table_center_x - text_width / 2, table_center_y - 20),
+            (table_center_x - pot_width / 2, pot_y),
             pot_text,
             fill=text_color,
-            font=self.title_font,
+            font=self.player_font,
         )
 
         return self.img, self.draw

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -43,7 +43,9 @@ class TableDrawer:
         highlight_color = (40, 40, 40, 255)
         bg = Image.new("RGBA", (self.config.width, self.config.height), base_color)
 
-        highlight = Image.new("RGBA", (self.config.width, self.config.height), highlight_color)
+        highlight = Image.new(
+            "RGBA", (self.config.width, self.config.height), highlight_color
+        )
         mask = Image.new("L", (self.config.width, self.config.height), 0)
         mask_draw = ImageDraw.Draw(mask)
 
@@ -111,7 +113,9 @@ class TableDrawer:
         # ------------------------------------------------------------------
         # Background shadow of the table
         # ------------------------------------------------------------------
-        shadow_overlay = Image.new("RGBA", (self.config.width, self.config.height), (0, 0, 0, 0))
+        shadow_overlay = Image.new(
+            "RGBA", (self.config.width, self.config.height), (0, 0, 0, 0)
+        )
         shadow_draw = ImageDraw.Draw(shadow_overlay, "RGBA")
         shadow_offset = depth * 2
         shadow_bbox = [
@@ -141,9 +145,7 @@ class TableDrawer:
             radius=radius + border_thickness,
             fill=wood_color,
         )
-        overlay_draw.rounded_rectangle(
-            bottom_bbox, radius=radius, fill=darker_color
-        )
+        overlay_draw.rounded_rectangle(bottom_bbox, radius=radius, fill=darker_color)
 
         # Draw the flat wooden border on top
         overlay_draw.rounded_rectangle(
@@ -186,7 +188,9 @@ class TableDrawer:
         shadow_mask = shadow_mask.filter(
             ImageFilter.GaussianBlur(radius=max(1, inner_width // 2))
         )
-        inner_shadow = Image.new("RGBA", (self.config.width, self.config.height), (0, 0, 0, 80))
+        inner_shadow = Image.new(
+            "RGBA", (self.config.width, self.config.height), (0, 0, 0, 80)
+        )
         inner_shadow.putalpha(shadow_mask)
         table_overlay = Image.alpha_composite(table_overlay, inner_shadow)
 
@@ -215,9 +219,9 @@ class TableDrawer:
             logo = Image.open(logo_path).convert("RGBA")
             max_w = accent_bbox[2] - accent_bbox[0]
             max_h = accent_bbox[3] - accent_bbox[1]
-            logo.thumbnail((max_w, max_h), Image.LANCZOS)
-            logo = logo.rotate(-5, resample=Image.BICUBIC, expand=True)
-            alpha = logo.split()[-1].point(lambda a: int(a * 0.7))
+            target_size = (int(max_w * 0.5), int(max_h * 0.5))
+            logo.thumbnail(target_size, Image.LANCZOS)
+            alpha = logo.split()[-1].point(lambda a: int(a * 0.2))
             logo.putalpha(alpha)
             lx = int(table_center_x - logo.width / 2)
             ly = int(table_center_y - logo.height / 2)

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -215,14 +215,31 @@ class TableDrawer:
             os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
             "flow_logo.png",
         )
+        logo_height = 0
         if os.path.exists(logo_path):
             logo = Image.open(logo_path).convert("RGBA")
             max_w = accent_bbox[2] - accent_bbox[0]
             max_h = accent_bbox[3] - accent_bbox[1]
-            target_size = (int(max_w * 0.35), int(max_h * 0.35))
-            logo.thumbnail(target_size, Image.LANCZOS)
-            alpha = logo.split()[-1].point(lambda a: int(a * 0.2))
-            logo.putalpha(alpha)
+            logo_height = logo.height
+        # Scenario description above the logo
+        scenario_text = self.game_data.get_scenario_description()
+        scenario_width = self.draw.textlength(scenario_text, font=self.title_font)
+        scenario_height = self.title_font.getbbox(scenario_text)[3]
+        scenario_y = (
+            table_center_y - logo_height / 2 - scenario_height - 5
+        )
+        self.draw.text(
+            (table_center_x - scenario_width / 2, scenario_y),
+            scenario_text,
+            fill=text_color,
+            font=self.title_font,
+        )
+
+        # Draw the pot below the logo
+        pot_width = self.draw.textlength(pot_text, font=self.player_font)
+        pot_y = table_center_y + logo_height / 2 + 5
+            (table_center_x - pot_width / 2, pot_y),
+            font=self.player_font,
             lx = int(table_center_x - logo.width / 2)
             ly = int(table_center_y - logo.height / 2)
             table_overlay.alpha_composite(logo, (lx, ly))

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -219,7 +219,7 @@ class TableDrawer:
             logo = Image.open(logo_path).convert("RGBA")
             max_w = accent_bbox[2] - accent_bbox[0]
             max_h = accent_bbox[3] - accent_bbox[1]
-            target_size = (int(max_w * 0.5), int(max_h * 0.5))
+            target_size = (int(max_w * 0.35), int(max_h * 0.35))
             logo.thumbnail(target_size, Image.LANCZOS)
             alpha = logo.split()[-1].point(lambda a: int(a * 0.2))
             logo.putalpha(alpha)

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -3,6 +3,7 @@ Module for drawing the poker table and its components.
 """
 
 from PIL import Image, ImageDraw, ImageFilter
+import os
 
 
 class TableDrawer:
@@ -188,6 +189,39 @@ class TableDrawer:
         inner_shadow = Image.new("RGBA", (self.config.width, self.config.height), (0, 0, 0, 80))
         inner_shadow.putalpha(shadow_mask)
         table_overlay = Image.alpha_composite(table_overlay, inner_shadow)
+
+        # --------------------------------------------------------------
+        # Accent line and center logo
+        # --------------------------------------------------------------
+        accent_inset = max(1, border_thickness // 3)
+        accent_bbox = [
+            top_bbox[0] + accent_inset,
+            top_bbox[1] + accent_inset,
+            top_bbox[2] - accent_inset,
+            top_bbox[3] - accent_inset,
+        ]
+        overlay_draw.rounded_rectangle(
+            accent_bbox,
+            radius=radius - accent_inset,
+            outline=(255, 255, 255, 80),
+            width=max(1, line_width // 2),
+        )
+
+        logo_path = os.path.join(
+            os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+            "flow_logo.png",
+        )
+        if os.path.exists(logo_path):
+            logo = Image.open(logo_path).convert("RGBA")
+            max_w = accent_bbox[2] - accent_bbox[0]
+            max_h = accent_bbox[3] - accent_bbox[1]
+            logo.thumbnail((max_w, max_h), Image.LANCZOS)
+            logo = logo.rotate(-5, resample=Image.BICUBIC, expand=True)
+            alpha = logo.split()[-1].point(lambda a: int(a * 0.7))
+            logo.putalpha(alpha)
+            lx = int(table_center_x - logo.width / 2)
+            ly = int(table_center_y - logo.height / 2)
+            table_overlay.alpha_composite(logo, (lx, ly))
 
         overlay_draw.rounded_rectangle(
             outer_top_bbox,


### PR DESCRIPTION
## Summary
- draw a subtle accent line along the table's inside edge
- place the Flow Poker Team logo on the table surface

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68586d6863d88333b3ff3da9bfd8d7fa