### PR TITLE
Add scenario text from solution path

### DIFF
--- a/batch_visualizer.py
+++ b/batch_visualizer.py
@@ -242,7 +242,11 @@ class BatchVisualizer:
 
                 # Create visualization
                 visualizer = PokerTableVisualizer(
-                    clean_json, card1, card2, str(output_path)
+                    clean_json,
+                    card1,
+                    card2,
+                    str(output_path),
+                    solution_path=str(file_path),
                 )
                 visualizer.create_visualization()
 

--- a/pipeline.py
+++ b/pipeline.py
@@ -104,7 +104,13 @@ if filtered_hands:
         output_path = os.path.join(visualization_dir, f"{hand}_{action}_{ev:.6f}.png")
 
         # Create visualization
-        visualizer = PokerTableVisualizer(clean_json, card1, card2, output_path)
+        visualizer = PokerTableVisualizer(
+            clean_json,
+            card1,
+            card2,
+            output_path,
+            solution_path=path,
+        )
         visualizer.create_visualization()
 
         print(

--- a/poker_viz/game_data.py
+++ b/poker_viz/game_data.py
@@ -6,14 +6,20 @@ Game data processing module for poker table visualization.
 class GameDataProcessor:
     """Process poker game data from JSON format."""
 
-    def __init__(self, json_data):
+    def __init__(self, json_data, solution_path=None):
         """
         Initialize the game data processor.
 
         Args:
             json_data: The JSON data containing poker game information
+            solution_path (str, optional): Path to the original solution file.
+                This is used to extract additional scenario information such as
+                average stack and percentage of field left.
         """
         self.data = json_data
+        self.solution_path = solution_path
+        self.parsed_avg_stack = None
+        self.parsed_field_left = None
         self.process_game_data()
 
     def process_game_data(self):
@@ -41,11 +47,54 @@ class GameDataProcessor:
             # Convert chips_on_table to float or default to 0
             player["chips_on_table"] = float(player.get("chips_on_table", 0))
 
+        # Parse additional scenario info from the solution path if provided
+        if self.solution_path:
+            self._parse_solution_path()
+
+    def _parse_solution_path(self):
+        """Extract average stack and field left information from the solution path."""
+        import os
+        import re
+
+        try:
+            path_parts = os.path.normpath(self.solution_path).split(os.sep)
+            # Look for the directory starting with 'MTT'
+            game_dir = next((p for p in path_parts if p.startswith("MTT")), "")
+
+            # Extract field left information
+            field_desc = None
+            pct_match = re.search(r"PCT(\d+)", game_dir)
+            if pct_match:
+                field_desc = f"{pct_match.group(1)}% Field left"
+            elif "START" in game_dir:
+                field_desc = "100% Field left"
+            elif "FT" in game_dir:
+                field_desc = "Final table"
+            elif "BUBBLEMID" in game_dir:
+                field_desc = "Near bubble"
+
+            self.parsed_field_left = field_desc
+
+            # Extract average stack from depth directory
+            depth_part = next((p for p in path_parts if p.startswith("depth_")), "")
+            if depth_part:
+                try:
+                    self.parsed_avg_stack = int(depth_part.split("_")[1])
+                except (IndexError, ValueError):
+                    self.parsed_avg_stack = None
+        except Exception:
+            self.parsed_avg_stack = None
+            self.parsed_field_left = None
+
     def get_scenario_description(self):
         """Return a simple scenario description string."""
         if not self.players:
             return ""
+        # If we parsed information from the solution path, use that
+        if self.parsed_avg_stack is not None and self.parsed_field_left:
+            return f"Average: {self.parsed_avg_stack}BB, {self.parsed_field_left}"
 
+        # Fallback to using data from the JSON itself
         avg_stack = sum(float(p.get("stack", 0)) for p in self.players) / len(
             self.players
         )

--- a/poker_viz/poker_table_visualizer.py
+++ b/poker_viz/poker_table_visualizer.py
@@ -17,7 +17,12 @@ class PokerTableVisualizer:
     """Main class for creating poker table visualizations."""
 
     def __init__(
-        self, json_data, card1=None, card2=None, output_path="poker_table.png"
+        self,
+        json_data,
+        card1=None,
+        card2=None,
+        output_path="poker_table.png",
+        solution_path=None,
     ):
         """
         Initialize the poker table visualizer.
@@ -32,6 +37,7 @@ class PokerTableVisualizer:
         self.card1 = card1
         self.card2 = card2
         self.output_path = output_path
+        self.solution_path = solution_path
 
         # Path to card images
         self.cards_folder = os.path.join(
@@ -55,7 +61,7 @@ class PokerTableVisualizer:
         self.title_font, self.player_font, self.card_font = self.config.load_fonts()
 
         # Process game data
-        self.game_data = GameDataProcessor(json_data)
+        self.game_data = GameDataProcessor(json_data, solution_path=solution_path)
 
         # Initialize drawers
         self._init_drawers()
@@ -188,7 +194,7 @@ def main():
     card2 = "Kd"  # King of diamonds - change this as needed
 
     # Create the visualization
-    visualizer = PokerTableVisualizer(data, card1, card2)
+    visualizer = PokerTableVisualizer(data, card1, card2, solution_path=json_file)
     output_path = visualizer.create_visualization()
 
     print(f"Open {output_path} to see the poker table visualization")

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -244,9 +244,9 @@ class TableDrawer:
 
         # Scenario description above the logo
         scenario_text = self.game_data.get_scenario_description()
-        scenario_width = self.draw.textlength(scenario_text, font=self.title_font)
+        scenario_width = self.draw.textlength(scenario_text, font=self.player_font)
         scenario_height = self.title_font.getbbox(scenario_text)[3]
-        scenario_y = table_center_y - logo_height / 2 - scenario_height - 5
+        scenario_y = table_center_y - logo_height / 4 - scenario_height - 10
         self.draw.text(
             (table_center_x - scenario_width / 2, scenario_y),
             scenario_text,

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -247,12 +247,12 @@ class TableDrawer:
         scenario_width = self.draw.textlength(scenario_text, font=self.title_font)
         scenario_height = self.title_font.getbbox(scenario_text)[3]
         scenario_y = table_center_y - logo_height / 2 - scenario_height - 5
-        # self.draw.text(
-        #     (table_center_x - scenario_width / 2, scenario_y),
-        #     scenario_text,
-        #     fill=text_color,
-        #     font=self.player_font,
-        # )
+        self.draw.text(
+            (table_center_x - scenario_width / 2, scenario_y),
+            scenario_text,
+            fill=text_color,
+            font=self.player_font,
+        )
 
         # Draw the pot below the logo
         pot_text = f"Pot: {self.game_data.pot} BB"


### PR DESCRIPTION
## Summary
- include path info when processing game data
- draw scenario description on the table
- pass the JSON file path through the visualizer API
- show scenario text in example script, pipeline and batch visualizer

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_685a1759b0908333bd2f0ac365ce48b6