### PR TITLE
Optimize poker image generation

### DIFF
--- a/hand_image_server.py
+++ b/hand_image_server.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 app = Flask(__name__)
 
 # Global cache for visualizer instances
-# Keys will be (game_type, num_players, hero_position)
+# Keys will be (num_players, hero_position)
 visualizer_cache = {}
 
 
@@ -73,7 +73,7 @@ def init_visualizer_cache():
             )
 
             # Create a visualizer instance for this configuration if it doesn't exist
-            cache_key = (game_type, num_players, hero_position)
+            cache_key = (num_players, hero_position)
             if cache_key not in visualizer_cache:
                 logger.info(
                     f"Creating visualizer for game type {game_type} with {num_players} players"
@@ -228,12 +228,12 @@ def create_visualization_from_json(hand_json):
                 )
 
                 # Try to get a cached visualizer for this configuration
-                cache_key = (game_type, num_players, hero_position)
+                cache_key = (num_players, hero_position)
 
                 if cache_key in visualizer_cache:
                     # Use the cached visualizer
                     logger.info(
-                        f"Using cached visualizer for {game_type} with {num_players} players and hero {hero_position}"
+                        f"Using cached visualizer for {num_players} players and hero {hero_position}"
                     )
                     visualizer = visualizer_cache[cache_key]
 
@@ -245,7 +245,7 @@ def create_visualization_from_json(hand_json):
                 else:
                     # Create a new visualizer and add it to the cache
                     logger.info(
-                        f"Creating new visualizer for {game_type} with {num_players} players and hero {hero_position}"
+                        f"Creating new visualizer for {num_players} players and hero {hero_position}"
                     )
                     visualizer = PokerTableVisualizer(
                         original_json,

--- a/poker_viz/game_data.py
+++ b/poker_viz/game_data.py
@@ -22,6 +22,19 @@ class GameDataProcessor:
         self.parsed_field_left = None
         self.process_game_data()
 
+    def update_data(self, json_data, solution_path=None):
+        """Update the stored JSON data and reprocess it."""
+
+        self.data = json_data
+        if solution_path is not None:
+            self.solution_path = solution_path
+
+        # Clear cached info so it can be recalculated
+        self.parsed_avg_stack = None
+        self.parsed_field_left = None
+
+        self.process_game_data()
+
     def process_game_data(self):
         """Extract relevant information from the JSON data."""
         self.game = self.data.get("game", {})

--- a/poker_viz/player_drawer.py
+++ b/poker_viz/player_drawer.py
@@ -140,8 +140,16 @@ class PlayerDrawer:
 
         return self.img, self.draw
 
-    def draw_player_rectangles(self):
-        """Draw all player info rectangles on top of the background circles."""
+    def draw_player_rectangles(self, draw_info=True):
+        """Draw all player rectangles on top of the background circles.
+
+        Parameters
+        ----------
+        draw_info : bool, optional
+            If True also draw the player position and stack text inside each
+            rectangle. When creating a static template this can be disabled so
+            only the heavy shapes are rendered once at start up.
+        """
         # Draw each player's rectangle using stored positions
         if not hasattr(self, "player_positions"):
             # If draw_player_circles wasn't called first, get the positions now
@@ -156,14 +164,46 @@ class PlayerDrawer:
             # Calculate rectangle dimensions
             player_radius = self.config.player_radius
             rect_width = player_radius * 1.8
-            rect_height = player_radius * 1.2  # Draw the rectangle with player info
+            rect_height = player_radius * 1.2
+
             self._draw_player_rectangle(
-                x, y, rect_width, rect_height, player_color, player
+                x,
+                y,
+                rect_width,
+                rect_height,
+                player_color,
+                player,
+                draw_info=draw_info,
             )
 
             # Draw dealer button if this player is the dealer
             if pos_info["is_dealer"]:
                 self._draw_dealer_button(x, y, pos_info.get("seat_index", 0))
+
+        return self.img, self.draw
+
+    def draw_player_text(self):
+        """Draw only the player information text on top of pre-rendered shapes."""
+
+        position_to_seat = self.game_data.get_position_mapping()
+
+        for player in self.game_data.players:
+            position = player.get("position")
+            is_hero = player.get("is_hero", False)
+
+            if is_hero:
+                seat_index = 0
+            elif position in position_to_seat:
+                seat_index = position_to_seat[position]
+            else:
+                seat_index = min(8, len(self.config.seat_positions) - 1)
+
+            x, y = self._get_safe_seat_position(seat_index)
+
+            player_radius = self.config.player_radius
+            rect_height = player_radius * 1.2
+
+            self._draw_player_info(x, y, player, rect_height)
 
         return self.img, self.draw
 
@@ -291,8 +331,19 @@ class PlayerDrawer:
         self.img = Image.alpha_composite(self.img, border_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")  # Recreate the draw object
 
-    def _draw_player_rectangle(self, x, y, width, height, player_color, player):
-        """Draw a rounded rectangle with player position and stack information."""
+    def _draw_player_rectangle(
+        self, x, y, width, height, player_color, player, draw_info=True
+    ):
+        """Draw a rounded rectangle for a player.
+
+        Parameters
+        ----------
+        draw_info : bool, optional
+            When ``True`` also render the position and stack text inside the
+            rectangle. This allows the heavy rectangle shapes to be rendered
+            once for a template and the text to be drawn later when generating
+            images.
+        """
         scale_factor = self.config.scale_factor
         text_color = self.config.text_color
         corner_radius = height * 0.3  # Rounded corners
@@ -386,8 +437,9 @@ class PlayerDrawer:
         self.img = Image.alpha_composite(self.img, border_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")  # Recreate the draw object
 
-        # Draw player information inside the rectangle
-        self._draw_player_info(x, y, player, height)
+        # Draw player information inside the rectangle if requested
+        if draw_info:
+            self._draw_player_info(x, y, player, height)
 
     def _draw_player_info(self, x, y, player, rect_height):
         """Draw player position and stack information inside the rectangle."""

--- a/poker_viz/player_drawer.py
+++ b/poker_viz/player_drawer.py
@@ -77,13 +77,20 @@ class PlayerDrawer:
 
         return self.img, self.draw
 
-    def draw_player_circles(self):
-        """Draw all player background circles around the table."""
+    def draw_player_circles(self, compute_only=False):
+        """Draw all player background circles around the table or just compute positions.
+
+        Parameters
+        ----------
+        compute_only : bool, optional
+            If ``True`` only compute the player positions without drawing the
+            circles. This is useful when generating a separate overlay that
+            should only contain the rectangles."""
         # Get position mapping
         position_to_seat = self.game_data.get_position_mapping()
 
         # Store player info for later use in draw_player_rectangles
-        self.player_positions = []  # Draw each player's background circle
+        self.player_positions = []
         for player in self.game_data.players:
             position = player.get("position")
             is_hero = player.get("is_hero", False)
@@ -130,13 +137,14 @@ class PlayerDrawer:
                 }
             )
 
-            # Draw just the background circle
-            self._draw_background_circle(
-                x,
-                y - 0.8 * self.config.player_radius,
-                self.config.player_radius,
-                player_color,
-            )
+            if not compute_only:
+                # Draw just the background circle
+                self._draw_background_circle(
+                    x,
+                    y - 0.8 * self.config.player_radius,
+                    self.config.player_radius,
+                    player_color,
+                )
 
         return self.img, self.draw
 

--- a/poker_viz/poker_table_visualizer.py
+++ b/poker_viz/poker_table_visualizer.py
@@ -171,11 +171,19 @@ class PokerTableVisualizer:
         )
         rect_draw = ImageDraw.Draw(rect_overlay, "RGBA")
         overlay_player_drawer = PlayerDrawer(
-            self.config, self.game_data, rect_overlay, rect_draw
+            self.config,
+            self.game_data,
+            rect_overlay,
+            rect_draw,
         )
         overlay_player_drawer.set_fonts(
-            self.title_font, self.player_font, self.card_font
+            self.title_font,
+            self.player_font,
+            self.card_font,
         )
+        # Compute player positions without drawing circles
+        overlay_player_drawer.draw_player_circles(compute_only=True)
+        # Now draw only the rectangles onto the overlay
         rect_overlay, rect_draw = overlay_player_drawer.draw_player_rectangles(
             draw_info=False
         )

--- a/poker_viz/table_drawer.py
+++ b/poker_viz/table_drawer.py
@@ -89,8 +89,15 @@ class TableDrawer:
         self.draw = ImageDraw.Draw(self.img, "RGBA")
         self.draw.text((x, y), text, fill=fill, font=font)
 
-    def draw_table(self):
-        """Draw the poker table with a simple 3D effect."""
+    def draw_table(self, draw_text=True):
+        """Draw the poker table with a simple 3D effect.
+
+        Parameters
+        ----------
+        draw_text : bool, optional
+            If ``True`` also render the scenario and pot text. When preparing a
+            static template this can be disabled so text can be drawn later.
+        """
         # Get dimensions from config
         table_center_x = self.config.table_center_x
         table_center_y = self.config.table_center_y
@@ -319,7 +326,23 @@ class TableDrawer:
         self.img = Image.alpha_composite(self.img, table_overlay)
         self.draw = ImageDraw.Draw(self.img, "RGBA")
 
-        # Scenario description above the logo
+        if draw_text:
+            self.draw_table_text(table_center_x, table_center_y, logo_height)
+
+        return self.img, self.draw
+
+    def draw_table_text(self, table_center_x=None, table_center_y=None, logo_height=0):
+        """Draw the scenario and pot text on the already rendered table."""
+
+        if table_center_x is None:
+            table_center_x = self.config.table_center_x
+        if table_center_y is None:
+            table_center_y = self.config.table_center_y
+
+        scale_factor = self.config.scale_factor
+        text_color = self.config.text_color
+        scenario_text_color = self.config.scenario_text_color
+
         scenario_text = self.game_data.get_scenario_description()
         scenario_width = self.draw.textlength(scenario_text, font=self.player_font)
         scenario_height = self.title_font.getbbox(scenario_text)[3]
@@ -334,7 +357,6 @@ class TableDrawer:
             fill=scenario_text_color,
         )
 
-        # Draw the pot below the logo
         pot_text = f"Total Pot: {self.game_data.pot:.2f} BB"
         pot_width = self.draw.textlength(pot_text, font=self.player_font)
         pot_y = table_center_y + logo_height / 4 + 30


### PR DESCRIPTION
## Summary
- allow drawing player rectangles without info and expose `draw_player_text`
- support rendering table text separately
- preload player circles/cards in `create_template`
- keep cached templates across refresh
- update visualization workflow to only draw dynamic elements

## Testing
- `python -m py_compile hand_image_server.py poker_viz/*.py`

------
https://chatgpt.com/codex/tasks/task_e_687fc745a63c83338beec12d5b6fa541